### PR TITLE
Integrate NPS API

### DIFF
--- a/Landmarks/Model/Landmark.swift
+++ b/Landmarks/Model/Landmark.swift
@@ -34,4 +34,15 @@ struct Landmark: Hashable, Codable, Identifiable {
         var latitude: Double
         var longitude: Double
     }
+
+    init(id: Int, name: String, park: String, state: String, description: String, isFavorite: Bool, imageName: String, coordinates: Coordinates) {
+        self.id = id
+        self.name = name
+        self.park = park
+        self.state = state
+        self.description = description
+        self.isFavorite = isFavorite
+        self.imageName = imageName
+        self.coordinates = coordinates
+    }
 }

--- a/Landmarks/Model/ModelData.swift
+++ b/Landmarks/Model/ModelData.swift
@@ -9,7 +9,26 @@ import Foundation
 
 @Observable
 class ModelData {
-    var landmarks: [Landmark] = load("landmarkData.json")
+    var landmarks: [Landmark] = []
+
+    init() {
+        landmarks = load("landmarkData.json")
+        Task {
+            await fetchRemoteLandmarks()
+        }
+    }
+
+    @MainActor
+    private func fetchRemoteLandmarks() async {
+        do {
+            let remote = try await NPSService().fetchLandmarks()
+            if !remote.isEmpty {
+                landmarks = remote
+            }
+        } catch {
+            // If the network call fails, fall back to bundled data.
+        }
+    }
 }
 
 func load<T: Decodable>(_ filename: String) -> T {

--- a/Landmarks/Model/NPSService.swift
+++ b/Landmarks/Model/NPSService.swift
@@ -1,0 +1,51 @@
+import Foundation
+import CoreLocation
+
+struct NPSService {
+    struct APIResponse: Decodable {
+        let data: [NPSPark]
+    }
+    struct NPSPark: Decodable {
+        let id: String
+        let fullName: String
+        let description: String
+        let states: String
+        let latLong: String?
+    }
+
+    func fetchLandmarks() async throws -> [Landmark] {
+        guard let apiKey = ProcessInfo.processInfo.environment["NPS_API_KEY"], !apiKey.isEmpty else {
+            return []
+        }
+        var components = URLComponents(string: "https://developer.nps.gov/api/v1/parks")!
+        components.queryItems = [
+            URLQueryItem(name: "limit", value: "50"),
+            URLQueryItem(name: "api_key", value: apiKey)
+        ]
+        let (data, _) = try await URLSession.shared.data(from: components.url!)
+        let response = try JSONDecoder().decode(APIResponse.self, from: data)
+        return response.data.compactMap { park in
+            guard let coord = parseLatLong(park.latLong ?? "") else { return nil }
+            return Landmark(
+                id: park.id.hashValue,
+                name: park.fullName,
+                park: park.fullName,
+                state: park.states,
+                description: park.description,
+                isFavorite: false,
+                imageName: "turtlerock",
+                coordinates: Landmark.Coordinates(latitude: coord.latitude, longitude: coord.longitude)
+            )
+        }
+    }
+
+    private func parseLatLong(_ string: String) -> CLLocationCoordinate2D? {
+        let parts = string.split(separator: ",")
+        guard parts.count == 2 else { return nil }
+        let latPart = parts[0].trimmingCharacters(in: .whitespaces)
+        let longPart = parts[1].trimmingCharacters(in: .whitespaces)
+        guard let latValue = Double(latPart.replacingOccurrences(of: "lat:", with: "")),
+              let longValue = Double(longPart.replacingOccurrences(of: "long:", with: "")) else { return nil }
+        return CLLocationCoordinate2D(latitude: latValue, longitude: longValue)
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # Landmarks
 Test iOS application.
+
+This project loads landmark data from the bundled JSON file on launch and then
+attempts to update that data using the U.S. National Park Service public API.
+Provide your API key in the `NPS_API_KEY` environment variable when running the
+app to enable live data.


### PR DESCRIPTION
## Summary
- fetch park data from the U.S. National Park Service API
- fall back to bundled JSON when network loading fails
- add an initializer for `Landmark`
- document API key usage in README

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868657d0fc4832d9da587b587963289