### PR TITLE
Improve API key handling

### DIFF
--- a/Landmarks/Model/ModelData.swift
+++ b/Landmarks/Model/ModelData.swift
@@ -26,7 +26,8 @@ class ModelData {
                 landmarks = remote
             }
         } catch {
-            // If the network call fails, fall back to bundled data.
+            // Keep using bundled data when the network call fails.
+            print("Failed to fetch remote landmarks:", error)
         }
     }
 }

--- a/Landmarks/Model/NPSService.swift
+++ b/Landmarks/Model/NPSService.swift
@@ -2,6 +2,9 @@ import Foundation
 import CoreLocation
 
 struct NPSService {
+    enum NPSError: Error {
+        case missingAPIKey
+    }
     struct APIResponse: Decodable {
         let data: [NPSPark]
     }
@@ -14,8 +17,9 @@ struct NPSService {
     }
 
     func fetchLandmarks() async throws -> [Landmark] {
-        guard let apiKey = ProcessInfo.processInfo.environment["NPS_API_KEY"], !apiKey.isEmpty else {
-            return []
+        guard let apiKey = ProcessInfo.processInfo.environment["NPS_API_KEY"],
+              !apiKey.isEmpty else {
+            throw NPSError.missingAPIKey
         }
         var components = URLComponents(string: "https://developer.nps.gov/api/v1/parks")!
         components.queryItems = [

--- a/LandmarksTests/ModelDataTests.swift
+++ b/LandmarksTests/ModelDataTests.swift
@@ -1,9 +1,22 @@
 import XCTest
+import Foundation
 @testable import Landmarks
 
 final class ModelDataTests: XCTestCase {
     func testLandmarksLoaded() {
         let model = ModelData()
         XCTAssertFalse(model.landmarks.isEmpty)
+    }
+
+    func testNPSServiceRequiresAPIKey() async {
+        unsetenv("NPS_API_KEY")
+        do {
+            _ = try await NPSService().fetchLandmarks()
+            XCTFail("Expected missing key error")
+        } catch let error as NPSService.NPSError {
+            XCTAssertEqual(error, .missingAPIKey)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
     }
 }

--- a/README.md
+++ b/README.md
@@ -4,4 +4,5 @@ Test iOS application.
 This project loads landmark data from the bundled JSON file on launch and then
 attempts to update that data using the U.S. National Park Service public API.
 Provide your API key in the `NPS_API_KEY` environment variable when running the
-app to enable live data.
+app to enable live data. If no key is provided the app keeps using the bundled
+landmarks and `NPSService.fetchLandmarks()` throws `NPSError.missingAPIKey`.


### PR DESCRIPTION
## Summary
- throw `NPSError.missingAPIKey` instead of silently returning empty data
- log failures when `fetchRemoteLandmarks` doesn't load
- test the new behaviour
- document the error in README

## Testing
- `swiftc -parse Landmarks/Model/NPSService.swift Landmarks/Model/ModelData.swift Landmarks/Model/Landmark.swift` *(parses Swift files)*
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68692fb1daac832db70ad837eb1e4080